### PR TITLE
fix: lock xmlbuilder version to 9.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "dependencies": {
     "async": "~0.2.6",
     "jszip": "^3.1.2",
-    "xmlbuilder": ">=0.4.2"
+    "xmlbuilder": "^9.0.4"
   }
 }


### PR DESCRIPTION
This keeps xmlbuilder at 9.x, the version that is manually committed into node_modules in the old branch we used. This fixes installations with yarn while keeping the fixes that Jonathan made some years ago.